### PR TITLE
Fix #107 + also check for station alternate names

### DIFF
--- a/SETUP_INSTRUCTIONS.md
+++ b/SETUP_INSTRUCTIONS.md
@@ -32,7 +32,13 @@ In /app/config/app.php set the following to your personal hostname/preferences:
 
 	'url' => 'http://irail.dev',    // with http
    	'url-short' => 'irail.dev',     // without http
+   	
+## Step 5: Set up resources   	
 
-## Step 5: You're ready!
+ * `npm install`
+ * `bower install`
+ * `grunt`
+
+## Step 6: You're ready!
 
 Usually you should be ready to get started by visiting the hostname you have set up. If it does not work, log an [issue](https://github.com/iRail/hyperRail/issues/new). We'll help you out and fix the documentation for everyone else.

--- a/app/controllers/ClassicRedirectController.php
+++ b/app/controllers/ClassicRedirectController.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Facades\Redirect;
+
 class ClassicRedirectController extends \BaseController
 {
 
@@ -45,13 +47,15 @@ class ClassicRedirectController extends \BaseController
     {
         $departure = \hyperRail\StationString::convertToId($departure_station);
         $destination = \hyperRail\StationString::convertToId($destination_station);
+
         if ($departure != null && $destination != null) {
             header("HTTP/1.1 301 Moved Permanently");
-            header("Location: https://" . _DOMAIN_ . "/route" .
-                "?mode=train" . "&from=" . $departure->id . "&to=" . $destination->id . "&time="
+            return Redirect::to("https://" . _DOMAIN_ . "/route" .
+                "?from=" . $departure->{'@id'} . "&to=" . $destination->{'@id'} . "&time="
                 . date("Hi") . "&auto=true");
+        } else {
+            return "It looks like we couldn't convert your route request to the new format :(";
         }
-        return "It looks like we couldn't convert your route request to the new format :(";
     }
 
     public function redirectSettings()

--- a/app/hyperRail/StationString.php
+++ b/app/hyperRail/StationString.php
@@ -19,35 +19,32 @@ class StationString
         // For each station in the array of stations, attempt comparison
 
         foreach ($data->{"@graph"} as $station) {
+
             /*
              * Write an array with station name alternates
              *
              * This also solves multilanguage issues since the strings are simply converted
              * to the proper id :) This way, we can make iRail multilanguage!
              *
-             * $alternates = array(
-             * "Gent-Sint-Pieters" => array('Ghent-Sint-Pieters', 'Gent Sint Pieters', 'Ghent Sint Pieters')
-             * )
              */
-            $alternates[$stations->name] = array();
-            foreach ($stations->altentative as $alternate) {
-                $alternates[$stations->name][] = $alternate->{"@value"};
-            }
-
-            /*
-             * Assuming we have a list of station name alternates, we can do even more
-             * comparisons to ensure that this process is functional.
-             * TODO: write a function that loops through station name alternates
-             */
-
 
             /* If we can find the station name in the string,
              * we can return the station data if we get a hit!
-             * Arguably we need to check if there are multiple hits:
-             * TODO: check for multiple hits when using strpos()
              */
             if (strpos($station->name, $string) !== false) {
                 return $station;
+            }
+
+            /*
+             * Assuming the main name was not a hit, try the alternates
+             * If an alternate value matches, return the station
+             */
+            if (isset($station->alternative)) {
+                foreach ($station->alternative as $alternate) {
+                    if (strpos($alternate->{"@value"}, $string) !== false) {
+                        return $station;
+                    }
+                }
             }
         }
         // If there is no station id found for this string...


### PR DESCRIPTION
Just pushed a fix to the development branch that fixes the currently broken station redirect (as per #107):

Functional again:
Something like: https://irail.be/route/Antwerpen/Mechelen

New: taking station alternate names in consideration!
The following should work too: https://irail.be/route/Antwerpen/Malines

@pietercolpaert: You should probably set debug to false on the deployed version as well, since https://irail.be/route/Antwerpen/Mechelen currently shows the debug page