### PR TITLE
Modify "iRail is a member of (...)"

### DIFF
--- a/app/views/core/footer.blade.php
+++ b/app/views/core/footer.blade.php
@@ -1,6 +1,6 @@
 <footer class="footer container">
     <hr/>
-    <p class="small"><a href="{{ URL::to('language') }}">{{Lang::get('client.language')}}</a> | 'iRail' &copy; 2015, Open Knowledge Belgium. <a href="http://hello.iRail.be" target="_blank">{{Lang::get('client.isPartOf')}}</a> <a href="http://www.openknowledge.be/" target="_blank">Open Knowledge Belgium</a>. | <a href="{{ URL::to('contributors') }}">{{Lang::get('contributors.title')}}</a> | <a href="https://github.com/iRail/hyperRail"><i class="fa fa-github"></i></a></p>
+    <p class="small"><a href="{{ URL::to('language') }}">{{Lang::get('client.language')}}</a> | 'iRail' &copy; 2015, Open Knowledge Belgium. <a href="http://hello.iRail.be" target="_blank"></a>{{Lang::get('client.isPartOf')}} <a href="http://www.openknowledge.be/" target="_blank">Open Knowledge Belgium</a>. | <a href="{{ URL::to('contributors') }}">{{Lang::get('contributors.title')}}</a> | <a href="https://github.com/iRail/hyperRail"><i class="fa fa-github"></i></a></p>
 </footer>
 <script>
     var _gaq = [['_setAccount', 'UA-263695-8'], ['_trackPageview']];


### PR DESCRIPTION
Linking only "iRail" to hello.irail.be and leaving the "is a member of" string out of the link seems more logical