### PR TITLE
Fix production breaking url-short to named routes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+; Unix-style newlines
+[*]
+end_of_line = LF
+
+[*.php]
+indent_style = space
+indent_size = 4

--- a/README.md
+++ b/README.md
@@ -43,20 +43,13 @@ Optional, but can be useful.
 chmod -R 777 storage
 ```
 
-### Step 4: Set up hostname ###
-
-In /app/config/app.php set the following to your personal hostname/preferences:
-
-	'url' => 'http://irail.dev',    // with http
-   	'url-short' => 'irail.dev',     // without http
-   	
-### Step 5: Set up resources ###
+### Step 4: Set up resources ###
 
  * `npm install`
  * `bower install`
  * `grunt`
 
-### Step 6: You're ready! ###
+### Step 5: You're ready! ###
 
 Usually you should be ready to get started by visiting the hostname you have set up. If it does not work, log an [issue](https://github.com/iRail/hyperRail/issues/new). We'll help you out and fix the documentation for everyone else.
 

--- a/app/Http/Controllers/ClassicRedirectController.php
+++ b/app/Http/Controllers/ClassicRedirectController.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace app\Http\Controllers;
 
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Http\Request;
-use App\Http\Requests;
 
 class ClassicRedirectController extends Controller
 {
@@ -15,18 +14,18 @@ class ClassicRedirectController extends Controller
     }
 
     /**
-     * Redirect classic liveboards URL to the new location
+     * Redirect classic liveboards URL to the new location.
      */
     public function redirectBoard()
     {
-        return Redirect::to("http://" . Config::get('app.url-short') . "/liveboard", 301);
+        //return Redirect::to("http://" . Config::get('app.url-short') . "/liveboard", 301);
     }
 
     /**
      * Redirect classic liveboards URL to the new location
-     * and interpret the station name
+     * and interpret the station name.
      *
-     * @param  string, $station_provided_string.
+     * @param string, $station_provided_string.
      *
      * @return null|string
      */
@@ -34,20 +33,20 @@ class ClassicRedirectController extends Controller
     {
         $station_converted = \hyperRail\StationString::convertToId($station_provided_string);
         if ($station_converted != null) {
-            header("HTTP/1.1 301 Moved Permanently");
-            header("Location: https://" . Config::get('app.url-short') . "/station/" . $station_converted->id);
+            return Redirect::route('station.index', ['id' => $station_converted->id], 301);
         } else {
-            return 'Liveboard for the following station: ' . $station_provided_string . ' was not found.';
+            return 'Liveboard for the following station: '.$station_provided_string.' was not found.';
         }
-        return null;
+
+        return;
     }
 
     /**
      * Redirect classic liveboards URL to the new location
-     * and interpret two station names
+     * and interpret two station names.
      *
-     * @param  string $station  The first station.
-     * @param  string $station2 The second station.
+     * @param string $station  The first station.
+     * @param string $station2 The second station.
      *
      * @return string
      */
@@ -58,7 +57,7 @@ class ClassicRedirectController extends Controller
 
     /**
      * Redirect classic routing from the old iRail to the new
-     * way the routing is done
+     * way the routing is done.
      *
      * @param $departure_station,   the departure station.
      * @param $destination_station, the destination station.
@@ -70,15 +69,18 @@ class ClassicRedirectController extends Controller
         $departure = \hyperRail\StationString::convertToId($departure_station);
         $destination = \hyperRail\StationString::convertToId($destination_station);
         if ($departure != null && $destination != null) {
-            header("HTTP/1.1 301 Moved Permanently");
-            return Redirect::to("https://" . Config::get('app.url-short') . "/route" .
-                "?from=" . $departure->{'@id'} . "&to=" . $destination->{'@id'} . "&time="
-                . date("Hi") . "&auto=true");
+            // header("HTTP/1.1 301 Moved Permanently");
+            //return Redirect::to("https://" . Config::get('app.url-short') . "/route" .
+            //  "?from=" . $departure->{'@id'} . "&to=" . $destination->{'@id'} . "&time="
+            //  . date("Hi") . "&auto=true");
+
+            // return to Main route as $departure->{'@id'} returns full URL
+            return Redirect::action('RouteController@index', 301);
         } else {
             return "It looks like we couldn't convert your route request to the new format :(";
         }
     }
-    
+
     public function redirectSettings()
     {
         return 'iRail has been changed. iRail no longer has a dedicated settings page.';

--- a/app/Http/Controllers/ClassicRedirectController.php
+++ b/app/Http/Controllers/ClassicRedirectController.php
@@ -19,6 +19,7 @@ class ClassicRedirectController extends Controller
     public function redirectBoard()
     {
         //return Redirect::to("http://" . Config::get('app.url-short') . "/liveboard", 301);
+        return Redirect::action('RouteController@index', [], 301);
     }
 
     /**
@@ -75,7 +76,7 @@ class ClassicRedirectController extends Controller
             //  . date("Hi") . "&auto=true");
 
             // return to Main route as $departure->{'@id'} returns full URL
-            return Redirect::action('RouteController@index', 301);
+            return Redirect::action('RouteController@index', [], 301);
         } else {
             return "It looks like we couldn't convert your route request to the new format :(";
         }

--- a/app/Http/Controllers/ClassicRedirectController.php
+++ b/app/Http/Controllers/ClassicRedirectController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace app\Http\Controllers;
+namespace App\Http\Controllers;
 
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Config;

--- a/app/Http/Controllers/StationController.php
+++ b/app/Http/Controllers/StationController.php
@@ -11,6 +11,8 @@ use irail\stations\Stations;
 use ML\JsonLD\JsonLD;
 use Negotiation\FormatNegotiator;
 use App\hyperRail\FormatConverter;
+use EasyRdf_Graph;
+use EasyRdf_Format;
 
 class StationController extends Controller
 {
@@ -20,13 +22,15 @@ class StationController extends Controller
     }
 
     /**
-     * Uses irail\stations\Stations to resolve the station
+     * Uses irail\stations\Stations to resolve the station.
+     *
      * @param string $query
+     *
      * @return object
      */
-    private function getStations($query = "")
+    private function getStations($query = '')
     {
-        if ($query && $query !== "") {
+        if ($query && $query !== '') {
             return Stations::getStations($query);
         } else {
             return Stations::getStations();
@@ -43,19 +47,19 @@ class StationController extends Controller
         $acceptHeader = Request::header('accept');
         $priorities = ['application/json', 'text/html', '*/*'];
         $result = $negotiator->getBest($acceptHeader, $priorities);
-        $val = "text/html";
+        $val = 'text/html';
         if (isset($result)) {
             $val = $result->getValue();
         }
         // Evaluate the preferred content type.
         switch ($val) {
-            case "text/html":
+            case 'text/html':
                 return View('stations.search');
                 break;
-            case "application/json":
-            case "application/ld+json":
+            case 'application/json':
+            case 'application/ld+json':
             default:
-                return Response::make(json_encode($this->getStations(Input::get("q"))), 200)
+                return Response::make(json_encode($this->getStations(Input::get('q'))), 200)
                     ->header('Content-Type', 'application/ld+json')
                     ->header('Vary', 'accept');
                 break;
@@ -63,7 +67,8 @@ class StationController extends Controller
     }
 
     /**
-     * Redirects to the stations page for NMBS
+     * Redirects to the stations page for NMBS.
+     *
      * @return \Illuminate\Http\RedirectResponse
      */
     public function redirectToNMBSStations()
@@ -73,9 +78,12 @@ class StationController extends Controller
 
     /**
      * Shows a train or train data, based on the accept-header.
+     *
      * @param $station_id
      * @param $liveboard_id
+     *
      * @return array
+     *
      * @throws EasyRdf_Exception
      */
     public function specificTrain($station_id, $liveboard_id)
@@ -91,21 +99,21 @@ class StationController extends Controller
         $datetime = strtotime($datetime);
         $archived = false;
 
-        if ($datetime < strtotime("now")) {
+        if ($datetime < strtotime('now')) {
             $archived = true;
         }
 
         switch ($val) {
-            case "text/html":
+            case 'text/html':
                 // Convert id to string for interpretation by old API
 
                 $stationStringName = Stations::getStationFromId($station_id);
 
-                if (! $archived) {
+                if (!$archived) {
                     // Set up path to old api
-                    $URL = "http://api.irail.be/liveboard/?station=" . urlencode($stationStringName->name) .
-                        "&date=" . date("mmddyy", $datetime) . "&time=" . date("Hi", $datetime) .
-                        "&fast=true&lang=nl&format=json";
+                    $URL = 'http://api.irail.be/liveboard/?station='.urlencode($stationStringName->name).
+                        '&date='.date('mmddyy', $datetime).'&time='.date('Hi', $datetime).
+                        '&fast=true&lang=nl&format=json';
 
                     // Get the contents.
                     $guzzleClient = new \GuzzleHttp\Client();
@@ -128,8 +136,8 @@ class StationController extends Controller
                     // If no match is found, attempt to look in the archive
                     // Fetch file using curl
                     $ch = curl_init(
-                        "http://archive.irail.be/" . 'irail?subject=' .
-                        urlencode('http://irail.be/stations/NMBS/' . $station_id . '/departures/' . $liveboard_id)
+                        'http://archive.irail.be/'.'irail?subject='.
+                        urlencode('http://irail.be/stations/NMBS/'.$station_id.'/departures/'.$liveboard_id)
                     );
                     curl_setopt($ch, CURLOPT_HEADER, 0);
                     $request_headers[] = 'Accept: text/turtle';
@@ -157,19 +165,19 @@ class StationController extends Controller
 
                     // First, define the context
                     $context = [
-                        "delay" => "http://semweb.mmlab.be/ns/rplod/delay",
-                        "platform" => "http://semweb.mmlab.be/ns/rplod/platform",
-                        "scheduledDepartureTime" => "http://semweb.mmlab.be/ns/rplod/scheduledDepartureTime",
-                        "headsign" => "http://vocab.org/transit/terms/headsign",
-                        "routeLabel" => "http://semweb.mmlab.be/ns/rplod/routeLabel",
-                        "stop" => [
-                            "@id" => "http://semweb.mmlab.be/ns/rplod/stop",
-                            "@type" => "@id"
+                        'delay' => 'http://semweb.mmlab.be/ns/rplod/delay',
+                        'platform' => 'http://semweb.mmlab.be/ns/rplod/platform',
+                        'scheduledDepartureTime' => 'http://semweb.mmlab.be/ns/rplod/scheduledDepartureTime',
+                        'headsign' => 'http://vocab.org/transit/terms/headsign',
+                        'routeLabel' => 'http://semweb.mmlab.be/ns/rplod/routeLabel',
+                        'stop' => [
+                            '@id' => 'http://semweb.mmlab.be/ns/rplod/stop',
+                            '@type' => '@id',
                         ],
-                        "seeAlso" => [
-                            "@id" => "http://www.w3.org/2000/01/rdf-schema#seeAlso",
-                            "@type" => "@id",
-                        ]
+                        'seeAlso' => [
+                            '@id' => 'http://www.w3.org/2000/01/rdf-schema#seeAlso',
+                            '@type' => '@id',
+                        ],
                     ];
 
                     // Next, encode the context as JSON
@@ -179,7 +187,7 @@ class StationController extends Controller
                     $compacted = JsonLD::compact($output, $jsonContext);
 
                     // Print the resulting JSON-LD!
-                    $urlToFind = 'NMBS/' . $station_id . '/departures/' . $liveboard_id;
+                    $urlToFind = 'NMBS/'.$station_id.'/departures/'.$liveboard_id;
                     $stationDataFallback = json_decode(JsonLD::toString($compacted, true));
 
                     foreach ($stationDataFallback->{'@graph'} as $graph) {
@@ -192,38 +200,39 @@ class StationController extends Controller
                     App::abort(404);
                 }
                 break;
-            case "application/json":
-            case "application/ld+json":
+            case 'application/json':
+            case 'application/ld+json':
             default:
                 $stationStringName = Stations::getStationFromId($station_id);
                 if (!$archived) {
-                    $URL = "http://api.irail.be/liveboard/?station=" . urlencode($stationStringName->name) .
-                        "&date=" . date("mmddyy", $datetime) . "&time=" . date("Hi", $datetime) .
-                        "&fast=true&lang=nl&format=json";
+                    $URL = 'http://api.irail.be/liveboard/?station='.urlencode($stationStringName->name).
+                        '&date='.date('mmddyy', $datetime).'&time='.date('Hi', $datetime).
+                        '&fast=true&lang=nl&format=json';
                     $data = file_get_contents($URL);
                     $newData = FormatConverter::convertLiveboardData($data, $station_id);
                     foreach ($newData['@graph'] as $graph) {
                         if (strpos($graph['@id'], $liveboard_id) !== false) {
                             $context = [
-                                "delay" => "http://semweb.mmlab.be/ns/rplod/delay",
-                                "platform" => "http://semweb.mmlab.be/ns/rplod/platform",
-                                "scheduledDepartureTime" => "http://semweb.mmlab.be/ns/rplod/scheduledDepartureTime",
-                                "headsign" => "http://vocab.org/transit/terms/headsign",
-                                "routeLabel" => "http://semweb.mmlab.be/ns/rplod/routeLabel",
-                                "stop" => [
-                                    "@id" => "http://semweb.mmlab.be/ns/rplod/stop",
-                                    "@type" => "@id"
+                                'delay' => 'http://semweb.mmlab.be/ns/rplod/delay',
+                                'platform' => 'http://semweb.mmlab.be/ns/rplod/platform',
+                                'scheduledDepartureTime' => 'http://semweb.mmlab.be/ns/rplod/scheduledDepartureTime',
+                                'headsign' => 'http://vocab.org/transit/terms/headsign',
+                                'routeLabel' => 'http://semweb.mmlab.be/ns/rplod/routeLabel',
+                                'stop' => [
+                                    '@id' => 'http://semweb.mmlab.be/ns/rplod/stop',
+                                    '@type' => '@id',
                                 ],
                             ];
-                            return ["@context" => $context, "@graph" => $graph];
+
+                            return ['@context' => $context, '@graph' => $graph];
                         }
                     }
                     App::abort(404);
                 } else {
                     // If no match is found, attempt to look in the archive
                     // Fetch file using curl
-                    $ch = curl_init("http://archive.irail.be/" . 'irail?subject=' .
-                        urlencode('http://irail.be/stations/NMBS/' . $station_id . '/departures/' . $liveboard_id));
+                    $ch = curl_init('http://archive.irail.be/'.'irail?subject='.
+                        urlencode('http://irail.be/stations/NMBS/'.$station_id.'/departures/'.$liveboard_id));
                     curl_setopt($ch, CURLOPT_HEADER, 0);
                     $request_headers[] = 'Accept: text/turtle';
                     curl_setopt($ch, CURLOPT_HTTPHEADER, $request_headers);
@@ -245,30 +254,30 @@ class StationController extends Controller
                     }
                     // First, define the context
                     $context = [
-                        "delay" => "http://semweb.mmlab.be/ns/rplod/delay",
-                        "platform" => "http://semweb.mmlab.be/ns/rplod/platform",
-                        "scheduledDepartureTime" => "http://semweb.mmlab.be/ns/rplod/scheduledDepartureTime",
-                        "headsign" => "http://vocab.org/transit/terms/headsign",
-                        "routeLabel" => "http://semweb.mmlab.be/ns/rplod/routeLabel",
-                        "stop" => [
-                            "@id" => "http://semweb.mmlab.be/ns/rplod/stop",
-                            "@type" => "@id"
+                        'delay' => 'http://semweb.mmlab.be/ns/rplod/delay',
+                        'platform' => 'http://semweb.mmlab.be/ns/rplod/platform',
+                        'scheduledDepartureTime' => 'http://semweb.mmlab.be/ns/rplod/scheduledDepartureTime',
+                        'headsign' => 'http://vocab.org/transit/terms/headsign',
+                        'routeLabel' => 'http://semweb.mmlab.be/ns/rplod/routeLabel',
+                        'stop' => [
+                            '@id' => 'http://semweb.mmlab.be/ns/rplod/stop',
+                            '@type' => '@id',
                         ],
-                        "seeAlso" => [
-                            "@id" => "http://www.w3.org/2000/01/rdf-schema#seeAlso",
-                            "@type" => "@id",
-                        ]
+                        'seeAlso' => [
+                            '@id' => 'http://www.w3.org/2000/01/rdf-schema#seeAlso',
+                            '@type' => '@id',
+                        ],
                     ];
                     // Next, encode the context as JSON
                     $jsonContext = json_encode($context);
                     // Compact the JsonLD by using @context
                     $compacted = JsonLD::compact($output, $jsonContext);
                     // Print the resulting JSON-LD!
-                    $urlToFind = 'NMBS/' . $station_id . '/departures/' . $liveboard_id;
+                    $urlToFind = 'NMBS/'.$station_id.'/departures/'.$liveboard_id;
                     $stationDataFallback = json_decode(JsonLD::toString($compacted, true));
                     foreach ($stationDataFallback->{'@graph'} as $graph) {
                         if (strpos($graph->{'@id'}, $urlToFind) !== false) {
-                            return ["@context" => $context, "@graph" => $graph];
+                            return ['@context' => $context, '@graph' => $graph];
                         }
                     }
                     App::abort(404);
@@ -280,41 +289,41 @@ class StationController extends Controller
     /**
      * Shows a liveboard or liveboard data, based on the accept-header.
      *
-     * @param  integer $id the id of the station.
+     * @param int $id the id of the station.
      *
      * @return \Illuminate\Http\Response
      */
     public function liveboard($id)
     {
-
         $guzzleClient = new \GuzzleHttp\Client();
         $negotiator = new FormatNegotiator();
         $acceptHeader = Request::header('accept');
         $priorities = ['application/json', 'text/html', '*/*'];
         $result = $negotiator->getBest($acceptHeader, $priorities);
-        $val = "text/html";
+        $val = 'text/html';
         //unless the negotiator has found something better for us
         if (isset($result)) {
             $val = $result->getValue();
         }
         switch ($val) {
-            case "text/html":
+            case 'text/html':
                 try {
                     $station = Stations::getStationFromId($id);
                     if ($station == null) {
                         throw new \App\Exceptions\StationConversionFailureException();
                     }
                     $data = ['station' => $station];
+
                     return Response::view('stations.liveboard', $data)
-                        ->header('Content-Type', "text/html")
+                        ->header('Content-Type', 'text/html')
                         ->header('Vary', 'accept');
                     break;
                 } catch (\App\Exceptions\StationConversionFailureException $ex) {
                     App::abort(404);
                 }
                 break;
-            case "application/json":
-            case "application/ld+json":
+            case 'application/json':
+            case 'application/ld+json':
             default:
                 try {
                     $stationStringName = Stations::getStationFromId($id);
@@ -323,29 +332,31 @@ class StationController extends Controller
                         throw new \App\Exceptions\StationConversionFailureException();
                     }
                     //Check for optional time parameters
-                    $datetime = Input::get("datetime");
+                    $datetime = Input::get('datetime');
 
                     if (isset($datetime) && strtotime($datetime)) {
                         $datetime = strtotime($datetime);
                     } else {
-                        $datetime = strtotime("now");
+                        $datetime = strtotime('now');
                     }
 
-                    $URL = "http://api.irail.be/liveboard/?station="
-                        . $stationStringName->name . "&fast=true&lang=nl&format=json&date="
-                        . date("mmddyy", $datetime) . "&time=" . date("Hi", $datetime);
+                    $URL = 'http://api.irail.be/liveboard/?station='
+                        .$stationStringName->name.'&fast=true&lang=nl&format=json&date='
+                        .date('mmddyy', $datetime).'&time='.date('Hi', $datetime);
 
                     $guzzleRequest = $guzzleClient->get($URL);
                     $data = $guzzleRequest->getBody();
 
                     try {
                         $newData = FormatConverter::convertLiveboardData($data, $id);
-                        $jsonLD = (string)json_encode($newData);
+                        $jsonLD = (string) json_encode($newData);
+
                         return Response::make($jsonLD, 200)
                             ->header('Content-Type', 'application/ld+json')
                             ->header('Vary', 'accept');
                     } catch (Exception $ex) {
                         $error = (string) json_encode(['error' => 'An error occured while parsing the data']);
+
                         return Response::make($error, 500)
                             ->header('Content-Type', 'application/json')
                             ->header('Vary', 'accept');

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -3,14 +3,12 @@
 /**
  * --------------------------------------------------------------------------
  * Application Routes
- * --------------------------------------------------------------------------
+ * --------------------------------------------------------------------------.
  *
  * Here is where you can register all of the routes for an application.
  * It's a breeze. Simply tell Laravel the URIs it should respond to
  * and give it the controller to call when that URI is requested.
- *
  */
-
 Route::get('/', 'Welcome@index');
 Route::get('/route', 'RouteController@index');
 Route::get('/language', 'LanguageController@index');
@@ -18,16 +16,23 @@ Route::get('/contributors', 'ContributorsController@showContributors');
 
 Route::get('/stations/', 'StationController@redirectToNMBSStations');
 Route::get('/stations/NMBS', 'StationController@index');
-Route::get('/stations/NMBS/{id}', 'StationController@liveboard');
+Route::get('/stations/NMBS/{id}', [
+    'as' => 'station.index',
+    'uses' => 'StationController@liveboard',
+]);
+
 Route::get('/stations/NMBS/{id}/departures', 'StationController@liveboard');// should list the departures
 Route::get('/stations/NMBS/{id}/departures/{trainHash}', 'StationController@specificTrain');
 
 Route::get('/stations/nmbs', 'StationController@index'); // should list stations
 Route::get('/stations/nmbs/{id}', 'StationController@liveboard'); // should list information about the station
 Route::get('/stations/nmbs/{id}/departures', 'StationController@liveboard'); // should list the departures
-Route::get('/stations/nmbs/{id}/departures/{trainHash}', 'StationController@specificTrain');
+Route::get('/stations/nmbs/{id}/departures/{trainHash}', [
+    'as' => 'stations.departures.hash',
+    'uses' => 'StationController@specificTrain',
+]);
 
-/**
+/*
  * --------------------------------------------------------------------------
  * Classic iRail redirection messages
  * --------------------------------------------------------------------------

--- a/app/hyperRail/Models/LiveboardItem.php
+++ b/app/hyperRail/Models/LiveboardItem.php
@@ -1,8 +1,6 @@
 <?php
-namespace App\hyperRail\Models;
 
-use Illuminate\Support\Facades\Config;
-use stdClass;
+namespace app\hyperRail\Models;
 
 class LiveboardItem
 {
@@ -18,6 +16,7 @@ class LiveboardItem
 
     /**
      * Set the values for this LiveboardItem.
+     *
      * @param $stationId
      * @param $requestDate
      * @param $requestTime
@@ -30,33 +29,43 @@ class LiveboardItem
     public function fill($stationId, $requestDate, $requestTime, $routeLabel, $headSign, $delay, $time, $platform)
     {
         $this->headsign = $headSign;
-        $this->routeLabel = preg_replace("/([A-Z]{1,2})(\d+)/", "$1 $2", $routeLabel);
-        $md5hash = md5($this->routeLabel . $this->headsign);
-        $this->stationURL = "http://"
-            . Config::get('app.url-short') . "/stations/NMBS/" .
-            $stationId . "/departures/" . $requestDate .
-            $requestTime . $md5hash;
+        $this->routeLabel = preg_replace("/([A-Z]{1,2})(\d+)/", '$1 $2', $routeLabel);
+        $this->stationURL = $this->getStationUrl($stationId, $requestDate, $requestTime);
         $this->delay = $delay;
         $this->scheduledDepartureTime = $time;
         $this->platform = $platform;
-        $this->destinationURL = "http://" . Config::get('app.url-short') . "/stations/NMBS/" . $stationId;
+        $this->destinationURL = route('station.index', [
+            'id' => $stationId,
+        ]);
     }
 
     /**
      * Converts this object to a JSON-LD compatible array (using @id).
+     *
      * @return array
      */
     public function toArray()
     {
         $dataArray = [
-            "@id" => $this->stationURL,
-            "delay" => $this->delay,
-            "platform" => $this->platform,
-            "scheduledDepartureTime" => $this->scheduledDepartureTime,
-            "stop" => $this->destinationURL,
-            "headsign" => $this->headsign,
-            "routeLabel" => $this->routeLabel
+            '@id' => $this->stationURL,
+            'delay' => $this->delay,
+            'platform' => $this->platform,
+            'scheduledDepartureTime' => $this->scheduledDepartureTime,
+            'stop' => $this->destinationURL,
+            'headsign' => $this->headsign,
+            'routeLabel' => $this->routeLabel,
         ];
+
         return $dataArray;
+    }
+
+    private function getStationUrl($stationId, $requestDate, $requestTime)
+    {
+        $md5hash = md5($this->routeLabel.$this->headsign);
+
+        return route('stations.departures.hash', [
+            'id' => $stationId,
+            'trainHash' => $requestDate.$requestTime.$md5hash,
+        ]);
     }
 }

--- a/contributing.md
+++ b/contributing.md
@@ -52,9 +52,9 @@ All these details will help people to fix any potential bugs.
 
 A pull request against this repo has the following things:
 
-### Only PR's to the development will be accepted.**
+### Only PR's to the development will be accepted.
 
-- **PSR-2 coding standard.**
-- **Must pass StyleCI and TravisCI.**
-- **A good description of what u have changed and/or added.**
-- **A specific PR title. No general title like: Improvements**
+- [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md) coding standard.
+- Must pass StyleCI and TravisCI.
+- A good description of what u have changed and/or added.
+- A specific PR title. No general title like: Improvements

--- a/resources/views/stations/departurearchive.blade.php
+++ b/resources/views/stations/departurearchive.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{Config::get('app.locale');}}">
+<html lang="{{ Config::get('app.locale') }}">
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -9,7 +9,7 @@
     <meta name="twitter:creator" content="@iRail">
     <meta name="twitter:title" content="iRail | {{$departureStation->name}} to {{str_replace('[NMBS/SNCB]', '', $station->headsign)}}">
     <meta name="twitter:domain" content="https://iRail.be">
-    <meta name="twitter:description" content="Train to {{str_replace(' [NMBS/SNCB]', '', $station->headsign)}} departing at {{$departureStation->name}} left at platform {{$station->platform}} at {{date('H:i', strtotime($station->scheduledDepartureTime))}}<?php if (!is_array($station->delay)){ if ($station->delay > 0){ echo "with a delay of " . ((int)($station->delay)/60) . ' minutes'; }}?> on {{date('d/m/y', strtotime($station->scheduledDepartureTime))}}.">
+    <meta name="twitter:description" content="Train to {{str_replace(' [NMBS/SNCB]', '', $station->headsign)}} departing at {{$departureStation->name}} left at platform {{$station->platform}} at {{date('H:i', strtotime($station->scheduledDepartureTime))}}<?php if (!is_array($station->delay)){ if ($station->delay > 0){ echo "with a delay of " . ((int)($station->delay)/60) . ' minutes' }}?> on {{date('d/m/y', strtotime($station->scheduledDepartureTime))}}.">
     <meta name="twitter:image" content="{{ URL::asset('images/train.jpg') }}">
     <meta property="og:title" content="iRail.be" />
     <meta property="og:type" content="website" />
@@ -46,7 +46,7 @@
                     <p class="h2">{{Lang::get('client.platform')}} {{$station->platform}}</p>
                     <p class="h1"><strong>{{$departureStation->name}}</strong></p>
                     <p class="h2">{{Lang::get('client.to')}}</p>
-                    <p class="h1"><strong>{{str_replace("[NMBS/SNCB]", "", $station->headsign);}}</strong></p>
+                    <p class="h1"><strong>{{ str_replace("[NMBS/SNCB]", "", $station->headsign) }}</strong></p>
                     <?php
                     if (!is_array($station->delay)) {
                         if ($station->delay > 0){

--- a/resources/views/stations/departuredetail.blade.php
+++ b/resources/views/stations/departuredetail.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{Config::get('app.locale');}}">
+<html lang="{{ Config::get('app.locale') }}">
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -49,13 +49,13 @@
                     if (is_array($station['delay']) && sizeof($station['delay'])>1) {
                         echo "<p class='label label-warning label-lg'>" . "cancelled" . " </p>";
                     }
-                    ?>			
+                    ?>
                     <br/>
                     <br/>
                     <p class="h2">{{Lang::get('client.platform')}} {{$station['platform']}}</p>
                     <p class="h1"><strong>{{$departureStation->name}}</strong></p>
                     <p class="h2">{{Lang::get('client.to')}}</p>
-                    <p class="h1"><strong>{{str_replace("[NMBS/SNCB]", "", $station['headsign']);}}</strong></p>
+                    <p class="h1"><strong>{{ str_replace("[NMBS/SNCB]", "", $station['headsign']) }}</strong></p>
                 </div>
             </div>
         </div>

--- a/resources/views/stations/liveboard.blade.php
+++ b/resources/views/stations/liveboard.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{!! Config::get('app.locale');!!}" ng-app="irailapp" ng-controller="StationLiveboardCtrl">
+<html lang="{!! Config::get('app.locale') !!}" ng-app="irailapp" ng-controller="StationLiveboardCtrl">
 @include('core.head')
 <body>
 <div class="wrapper">

--- a/resources/views/stations/search.blade.php
+++ b/resources/views/stations/search.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{!! Config::get('app.locale');!!}" ng-app="irailapp" ng-controller="StationSearchCtrl">
+<html lang="{!! Config::get('app.locale') !!}" ng-app="irailapp" ng-controller="StationSearchCtrl">
 @include('core.head')
 <body>
 <div class="wrapper">
@@ -15,9 +15,14 @@
                     </script>
                     <div class="form-group">
                         <label for="departure">{{Lang::get('client.stationName')}}</label>
-                        <input type="text" ng-model="departure" placeholder="{{Lang::get('client.stationSearchPlaceholder')}}" typeahead="station as station.name for station in getStations($viewValue)" typeahead-template-url="customTemplate.html" class="form-control input-lg" typeahead-on-select='focus()'>
+                        <input type="text" ng-model="departure"
+                               placeholder="{{Lang::get('client.stationSearchPlaceholder')}}"
+                               typeahead="station as station.name for station in getStations($viewValue)"
+                               typeahead-template-url="customTemplate.html" class="form-control input-lg"
+                               typeahead-on-select='focus()'>
                     </div>
-                    <a id="confirm" href="@{{departure['@id']}}" ng-show="departure['@id']" class="btn btn-primary btn-wide btn-lg bounceIn">{{Lang::get('client.viewLiveboard')}}</a>
+                    <a id="confirm" href="@{{departure['@id']}}" ng-show="departure['@id']"
+                       class="btn btn-primary btn-wide btn-lg bounceIn">{{ Lang::get('client.viewLiveboard') }}</a>
                 </div>
             </div>
         </div>

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -1,7 +1,7 @@
 <?php
 
 
-class routeTest extends TestCase
+class RouteTest extends TestCase
 {
     public function testRoute()
     {


### PR DESCRIPTION
Hello,

Due to the usage of url-short hard-coded in config there will be possibility for misconfiguration.
Currently on Production liveboard the urls point to localhost https://irail.be/stations/NMBS/008812005

This is solved with [Laravel named routes](http://laravel.com/docs/5.1/routing#named-routes). This will make sure that also on a local environment the url will adapt to the local hostname

### Changed in this commits
- Implemented [EditorConfig](http://editorconfig.org/)
- Contribution.md referenced to [PSR-2 Codestyle](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)
- Refactored url-short to use named routes instead. This gives also more flexibility once routes.php changes
- Removed trailing comma's in view that caused errors
- Added missing imports on `StationsController`
- Fixed coding style issues in `StationsController`

Please note that ClassicRedirectController is broken as the model doesn't return an ID but a full url with containing stationID. I've replaced this with redirection to `/route`

There are still some remaining issues on Production.
Please check [station departure](http://irail.be/stations/nmbs/008893120/departures/20150830102138b01935fec7e7e77f5e911b2445207a) but this should be logged as new issue in the issue tracker.
I've added already the missing imports in `StationsController` but this will return still 504 Gateway Time-out 