### PR TITLE
Add Laravel preset for StyleCi

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,2 @@
+preset: laravel
+


### PR DESCRIPTION
This config will make sure that the [Laravel](https://styleci.readme.io/docs/presets#laravel) is applied.
And this doesn't change the namespace mentioned in #138 

You could also configure your repository in StyleCi.io by adding `preset: laravel` see #154 