### PR TITLE
Add mobile capable meta tags

### DIFF
--- a/resources/views/core/head.blade.php
+++ b/resources/views/core/head.blade.php
@@ -2,6 +2,8 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-capable" content="yes">
     <link rel="apple-touch-icon-precomposed" href="{{ URL::asset('apple-touch-icon-precomposed.png') }}">
     <meta property="og:title" content="iRail.be" />
     <meta property="og:type" content="website" />


### PR DESCRIPTION
This will enable an experience on "save to homescreen" which is close to an app, because it will for example hide the browser chrome. This leaves the whole screen for content.