### PR TITLE
Lock angular version to 1.2.29

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,7 @@
     "angular-bootstrap": "~0.11.0",
     "angular-animate": "~1.2.18",
     "bootstrap-sass-official": "*",
-    "bootstrap-sass": "~3.0.2"
+    "bootstrap-sass": "~3.0.2",
+    "angular": "1.2.29"
   }
 }


### PR DESCRIPTION
### Fixed

- Lock angular to 1.2.29 so it works with angular-animate

---

Issue was that bower was installing angular 1.5.* which is not compatible with the locked angular-animate version.

https://github.com/iRail/hyperRail/issues/181