### PR TITLE
use correct url for occupancy feedback

### DIFF
--- a/public/app/js/iRail/Controllers/PlannerCtrl.js
+++ b/public/app/js/iRail/Controllers/PlannerCtrl.js
@@ -285,9 +285,9 @@ var PlannerCtrl = function ($scope, $http, $filter, $timeout, $window) {
 
     var data = {
       "connection": connection,
-      "occupancy" : "https://api.irail.be/terms/"+occupancy,
-      "vehicle"   : "https://irail.be/vehicle/" + vehicle.split('.')[2],
-      "from"      : "https://irail.be/stations/NMBS/00" + from,
+      "occupancy" : "http://api.irail.be/terms/"+occupancy,
+      "vehicle"   : "http://irail.be/vehicle/" + vehicle.split('.')[2],
+      "from"      : "http://irail.be/stations/NMBS/00" + from,
       "to"        : to,
       "date"      : departureTime
     }

--- a/public/app/js/iRail/Controllers/PlannerCtrl.js
+++ b/public/app/js/iRail/Controllers/PlannerCtrl.js
@@ -285,9 +285,9 @@ var PlannerCtrl = function ($scope, $http, $filter, $timeout, $window) {
 
     var data = {
       "connection": connection,
-      "occupancy" : "http://api.irail.be/terms/"+occupancy,
-      "vehicle"   : "http://irail.be/vehicle/" + vehicle.split('.')[2],
-      "from"      : "http://irail.be/station/NMBS/00" + from,
+      "occupancy" : "https://api.irail.be/terms/"+occupancy,
+      "vehicle"   : "https://irail.be/vehicle/" + vehicle.split('.')[2],
+      "from"      : "https://irail.be/stations/NMBS/00" + from,
       "to"        : to,
       "date"      : departureTime
     }


### PR DESCRIPTION
The correct API url for a station is `/stations/`, not `/station/`

Also change from `http` to `https`, since I don't see a downside (IMO we should redirect already).

The `to` parameter was already given the correct url. 