### PR TITLE
regular size of form control

### DIFF
--- a/public/app/sass/_shame.scss
+++ b/public/app/sass/_shame.scss
@@ -112,3 +112,11 @@ a.bounceIn.ng-hide-remove {
 .label-lg {
   font-size: 1.5em;
 }
+
+// override default form control
+// otherwise this is too small according to iOS
+// and it zooms in.
+.form-control {
+  font-size: 16px !important;
+  height: initial !important;
+}


### PR DESCRIPTION
By default this version of bootstrap adds a 14px font-size to form elements. It also hard codes a size. On iOS small form elements gets zoomed in until they're over 16px. That means that for a size difference that you can barely see, a zoom out needs to be done after entering the date.

fixes #230