### PR TITLE
make sure that the background-image icons are sized correctly

### DIFF
--- a/public/app/sass/_component.occupancy.scss
+++ b/public/app/sass/_component.occupancy.scss
@@ -6,25 +6,26 @@
 {
 	display:inline-block;
 	margin-right:6px;
+	background-size: contain;
 }
 
 .occupancy-high-16
 {
-	background:url(../../images/occupancy-high.svg);
+	background-image:url(../../images/occupancy-high.svg);
 	height:16px;
 	width:17px;
 }
 
 .occupancy-medium-16
 {
-	background:url(../../images/occupancy-medium.svg);
+	background-image:url(../../images/occupancy-medium.svg);
 	height:16px;
 	width:17px;
 }
 
 .occupancy-low-16
 {
-	background:url(../../images/occupancy-low.svg);
+	background-image:url(../../images/occupancy-low.svg);
 	height:16px;
 	width:17px;
 }


### PR DESCRIPTION
previously these were incidentally correctly sized pixel graphics, but now that it are vector graphics, they should be explicitly sized to fill the container instead of going for their native size.

see #231

before|after|(old)
---|---|---
<img width="154" alt="screen shot 2016-10-12 at 12 33 49" src="https://cloud.githubusercontent.com/assets/6270048/19306921/3c17b6dc-9078-11e6-8386-8e02181d8ce2.png">|<img width="161" alt="screen shot 2016-10-12 at 12 29 46" src="https://cloud.githubusercontent.com/assets/6270048/19306922/3c1cdff4-9078-11e6-8f33-b4ae25798c38.png">|<img width="167" alt="screen shot 2016-10-12 at 12 34 08" src="https://cloud.githubusercontent.com/assets/6270048/19306919/3bed983e-9078-11e6-8201-97241e2d5862.png">