### PR TITLE
add link around the 'iRail' logo to hello.irail.be

### DIFF
--- a/resources/views/core/footer.blade.php
+++ b/resources/views/core/footer.blade.php
@@ -1,6 +1,6 @@
 <footer class="footer container">
     <hr/>
-    <p class="small text-muted text-center"><a href="{{ URL::to('language') }}">{{Lang::get('client.language')}}</a> | 'iRail' - Open Knowledge Belgium. <a href="http://hello.iRail.be" target="_blank"></a>{{Lang::get('client.isPartOf')}} <a href="http://www.openknowledge.be/" target="_blank">Open Knowledge Belgium</a>. | <a href="{{ URL::to('contributors') }}">{{Lang::get('contributors.title')}}</a> | <a href="https://github.com/iRail/hyperRail"><i class="fa fa-github"></i></a></p>
+    <p class="small text-muted text-center"><a href="{{ URL::to('language') }}">{{Lang::get('client.language')}}</a> | <a href="http://hello.iRail.be" target="_blank">'iRail'</a> - Open Knowledge Belgium. {{Lang::get('client.isPartOf')}} <a href="http://www.openknowledge.be/" target="_blank">Open Knowledge Belgium</a>. | <a href="{{ URL::to('contributors') }}">{{Lang::get('contributors.title')}}</a> | <a href="https://github.com/iRail/hyperRail"><i class="fa fa-github"></i></a></p>
 
 </footer>
 <script>


### PR DESCRIPTION
Currently it is a link that is visible nowhere, but it was probably meant to link around the 'iRail' text in the footer

see https://github.com/iRail/hyperRail/pull/121

before|after
---|---
<img width="717" alt="screen shot 2016-10-12 at 13 00 30" src="https://cloud.githubusercontent.com/assets/6270048/19307701/2ad402e6-907c-11e6-8652-dc510df9aa96.png">|<img width="709" alt="screen shot 2016-10-12 at 13 00 37" src="https://cloud.githubusercontent.com/assets/6270048/19307708/31a95440-907c-11e6-8d91-a2758d2b8138.png">

