### PR TITLE
show the occupancy feedback more

### DIFF
--- a/resources/views/_partials/route/results.blade.php
+++ b/resources/views/_partials/route/results.blade.php
@@ -70,8 +70,8 @@
                             @{{stop.occupancy.name}}
 
                             <!-- Feedback form -->
-                            {{-- Show the feedback form 10 minutes before departure time and 10 minutes after arrival time --}}
-                            <div class="dropdown" ng-show="{{ time() - (10 * 60) }} >= @{{conn.departure.time }} && (@{{conn.arrival.time }} + {{10 * 60}}) > {{ time() }}">
+                            {{-- Show the feedback form 10 minutes before departure time --}}
+                            <div class="dropdown" ng-show="{{ time() + (10 * 60) }} >= @{{conn.departure.time }}">
                                 <button class="btn btn-link btn-link-subtle btn-xs dropdown-toggle" type="button" id="dropdownMenu2" aria-haspopup="true" aria-expanded="false">
                                     {{ Lang::get('client.howBusyIsThisTrain') }}
                                     <span class="caret"></span>


### PR DESCRIPTION
Always show when the current time is more than 10 minutes more than the departure time. 

(issue is that for some reason locally I keep seeing the old formula, even after changing it to this.)