### PR TITLE
Refactor feedback into a partial

### DIFF
--- a/resources/views/_partials/route/feedback/connection.blade.php
+++ b/resources/views/_partials/route/feedback/connection.blade.php
@@ -1,0 +1,48 @@
+{{-- Show the feedback form 10 minutes before connection departure time --}}
+<div class="dropdown" ng-show="{{ time() + (10 * 60) }} >= @{{conn.departure.time }}">
+    <button class="btn btn-link btn-link-subtle btn-xs dropdown-toggle" type="button" id="dropdownMenu2" aria-haspopup="true" aria-expanded="false">
+        {{ Lang::get('client.howBusyIsThisTrain') }}
+        <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" aria-labelledby="dropdownMenu2">
+        <li>
+            <a href="#"
+            ng-click="selectOccupancy($event)"
+            data-occupancy="high"
+            data-from="@{{conn.departure.stationinfo['@id']}}"
+            data-to="@{{conn.arrival.stationinfo['@id']}}"
+            data-date="@{{conn.departure.time}}"
+            data-vehicle="@{{conn.departure.vehicle}}"
+            data-connection="@{{conn.departure.departureConnection}}">
+                <i class="occupancy-icon occupancy-high-16"></i>
+                {{ Lang::get('client.highOccupied') }}
+            </a>
+        </li>
+        <li>
+            <a href="#"
+            ng-click="selectOccupancy($event)"
+            data-occupancy="medium"
+            data-from="@{{conn.departure.departureConnection}}"
+            data-to="@{{conn.arrival.stationinfo['@id']}}"
+            data-date="@{{conn.departure.time}}"
+            data-vehicle="@{{conn.departure.vehicle}}"
+            data-connection="@{{conn.departure.departureConnection}}">
+                <i class="occupancy-icon occupancy-medium-16"></i>
+                {{ Lang::get('client.mediumOccupied') }}
+            </a>
+        </li>
+        <li>
+            <a href="#"
+            ng-click="selectOccupancy($event)"
+            data-occupancy="low"
+            data-from="@{{conn.departure.departureConnection}}"
+            data-to="@{{conn.arrival.stationinfo['@id']}}"
+            data-date="@{{conn.departure.time}}"
+            data-vehicle="@{{conn.departure.vehicle}}"
+            data-connection="@{{conn.departure.departureConnection}}">
+                <i class="occupancy-icon occupancy-low-16"></i>
+                {{ Lang::get('client.lowOccupied') }}
+            </a>
+        </li>
+    </ul>
+</div>

--- a/resources/views/_partials/route/feedback/stop.blade.php
+++ b/resources/views/_partials/route/feedback/stop.blade.php
@@ -1,0 +1,48 @@
+{{-- Show the feedback form 10 minutes before connection departure time --}}
+<div class="dropdown" ng-show="{{ time() + (10 * 60) }} >= @{{conn.departure.time }}">
+    <button class="btn btn-link btn-link-subtle btn-xs dropdown-toggle" type="button" id="dropdownMenu2" aria-haspopup="true" aria-expanded="false">
+        {{ Lang::get('client.howBusyIsThisTrain') }}
+        <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" aria-labelledby="dropdownMenu2">
+        <li>
+            <a href="#"
+            ng-click="selectOccupancy($event)"
+            data-occupancy="high"
+            data-from="@{{stop.departure.stationinfo['id']}}"
+            data-to="@{{stop.stationinfo['@id']}}"
+            data-date="@{{stop.departure.time}}"
+            data-vehicle="@{{stop.vehicle}}"
+            data-connection="@{{stop.departure.departureConnection}}">
+                <i class="occupancy-icon occupancy-high-16"></i>
+                {{ Lang::get('client.highOccupied') }}
+            </a>
+        </li>
+        <li>
+            <a href="#"
+            ng-click="selectOccupancy($event)"
+            data-occupancy="medium"
+            data-from="@{{stop.departure.stationinfo['@id']}}"
+            data-to="@{{stop.stationinfo['@id']}}"
+            data-date="@{{stop.departure.time}}"
+            data-vehicle="@{{stop.vehicle}}"
+            data-connection="@{{stop.departure.departureConnection}}">
+                <i class="occupancy-icon occupancy-medium-16"></i>
+                {{ Lang::get('client.mediumOccupied') }}
+            </a>
+        </li>
+        <li>
+            <a href="#"
+            ng-click="selectOccupancy($event)"
+            data-occupancy="low"
+            data-from="@{{stop.departure.stationinfo['@id']}}"
+            data-to="@{{stop.stationinfo['@id']}}"
+            data-date="@{{stop.departure.time}}"
+            data-vehicle="@{{stop.vehicle}}"
+            data-connection="@{{stop.departure.departureConnection}}">
+                <i class="occupancy-icon occupancy-low-16"></i>
+                {{ Lang::get('client.lowOccupied') }}
+            </a>
+        </li>
+    </ul>
+</div>

--- a/resources/views/_partials/route/results.blade.php
+++ b/resources/views/_partials/route/results.blade.php
@@ -69,43 +69,8 @@
 
                             @{{stop.occupancy.name}}
 
-                            <!-- Feedback form -->
-                            {{-- Show the feedback form 10 minutes before departure time --}}
-                            <div class="dropdown" ng-show="{{ time() + (10 * 60) }} >= @{{conn.departure.time }}">
-                                <button class="btn btn-link btn-link-subtle btn-xs dropdown-toggle" type="button" id="dropdownMenu2" aria-haspopup="true" aria-expanded="false">
-                                    {{ Lang::get('client.howBusyIsThisTrain') }}
-                                    <span class="caret"></span>
-                                </button>
-                                <ul class="dropdown-menu" aria-labelledby="dropdownMenu2">
-                                    <li>
-                                        <a href="#" ng-click="selectOccupancy($event)" data-occupancy="high"
-                                        data-from="@{{stop.departure.departureConnection}}"
-                                        data-to="@{{stop.stationinfo['@id']}}"
-                                        data-date="@{{conn.departure.time}}"
-                                        data-vehicle="@{{stop.vehicle}}"
-                                        data-connection="@{{stop.departure.departureConnection}}"><i class="occupancy-icon occupancy-high-16"></i>{{ Lang::get('client.highOccupied') }}</a>
-                                    </li>
-                                    <li>
-                                        <a href="#"
-                                        ng-click="selectOccupancy($event)" data-occupancy="medium"
-                                        data-from="@{{stop.departure.departureConnection}}"
-                                        data-to="@{{stop.stationinfo['@id']}}"
-                                        data-date="@{{conn.departure.time}}"
-                                        data-vehicle="@{{stop.vehicle}}"
-                                        data-connection="@{{stop.departure.departureConnection}}"><i class="occupancy-icon occupancy-medium-16"></i>
-                                        {{ Lang::get('client.mediumOccupied') }}</a>
-                                    </li>
-                                    <li>
-                                        <a href="#" ng-click="selectOccupancy($event)" data-occupancy="low"
-                                        data-from="@{{stop.departure.departureConnection}}"
-                                        data-to="@{{stop.stationinfo['@id']}}"
-                                        data-date="@{{conn.departure.time}}"
-                                        data-vehicle="@{{stop.vehicle}}"
-                                        data-connection="@{{stop.departure.departureConnection}}"><i class="occupancy-icon occupancy-low-16"></i>{{ Lang::get('client.lowOccupied') }}</a>
-                                    </li>
-                                </ul>
-                            </div>
-                            <!-- /Feedback form -->
+                            @include('_partials.route.feedback.stop')
+
                         </span>
 
                         <div class="planner-row">
@@ -114,7 +79,7 @@
                             </span>
 
                             <span class="planner-station">
-                                <b>@{{ stop.station}}</b>
+                                <b>@{{ stop.station }}</b>
                             </span>
 
                             <span class="planner-platform">
@@ -125,8 +90,8 @@
                         <span class="planner-switch small text-muted">
                             @{{(stop.timeBetween/60)}} {{Lang::get('client.mins')}}
                             <br />
-                            {{Lang::get('client.fromPlatform')}} @{{ stop.arrival.platform }}
-                            {{Lang::get('client.toPlatform')}} @{{ stop.departure.platform }}
+                            {{ Lang::get('client.fromPlatform')}} @{{ stop.arrival.platform }}
+                            {{ Lang::get('client.toPlatform')}} @{{ stop.departure.platform }}
                         </span>
 
                         <div class="planner-row">
@@ -155,51 +120,8 @@
                         <span class="small">&ndash; @{{conn.arrival.vehicle.replace("BE.NMBS.","")}}</span>
                         <img ng-src="/images/occupancy-@{{conn.departure.occupancy.name}}.svg" alt="@{{conn.departure.occupancy.name}}" height="16" width="16" />
 
-                        <!-- Feedback form -->
-                        {{-- Show the feedback form 10 minutes before departure --}}
-                            <div class="dropdown" ng-show="{{ time() + (10 * 60) }} >= @{{conn.departure.time }}">
-                                <button class="btn btn-link btn-link-subtle btn-xs dropdown-toggle" type="button" id="dropdownMenu2" aria-haspopup="true" aria-expanded="false">
-                                    {{ Lang::get('client.howBusyIsThisTrain') }}
-                                    <span class="caret"></span>
-                                </button>
-                                <ul class="dropdown-menu" aria-labelledby="dropdownMenu2">
-                                    <li>
-                                        <a href="#"
-                                            ng-click="selectOccupancy($event)" data-occupancy="high"
-                                            data-from="@{{conn.departure.departureConnection}}"
-                                            data-to="@{{conn.arrival.stationinfo['@id']}}"
-                                            data-date="@{{conn.departure.time}}"
-                                            data-vehicle="@{{conn.departure.vehicle}}"
-                                            data-connection="@{{conn.departure.departureConnection}}"><i class="occupancy-icon occupancy-high-16"></i>
-                                            {{ Lang::get('client.highOccupied') }}
-                                        </a>
-                                    </li>
-                                    <li>
-                                        <a href="#"
-                                            ng-click="selectOccupancy($event)" data-occupancy="medium"
-                                            data-from="@{{conn.departure.departureConnection}}"
-                                            data-to="@{{conn.arrival.stationinfo['@id']}}"
-                                            data-date="@{{conn.departure.time}}"
-                                            data-vehicle="@{{conn.departure.vehicle}}"
-                                            data-connection="@{{conn.departure.departureConnection}}"><i class="occupancy-icon occupancy-medium-16"></i>
-                                            {{ Lang::get('client.mediumOccupied') }}
-                                        </a>
-                                    </li>
-                                    <li>
-                                        <a href="#"
-                                            ng-click="selectOccupancy($event)" data-occupancy="low"
-                                            data-from="@{{conn.departure.departureConnection}}"
-                                            data-to="@{{conn.arrival.stationinfo['@id']}}"
-                                            data-date="@{{conn.departure.time}}"
-                                            data-vehicle="@{{conn.departure.vehicle}}"
-                                            data-connection="@{{conn.departure.departureConnection}}"><i class="occupancy-icon occupancy-low-16"></i>
-                                            {{ Lang::get('client.lowOccupied') }}
-                                        </a>
-                                    </li>
-                                  </ul>
-                                </div>
+                        @include('_partials.route.feedback.connection')
 
-                        <!-- /Feedback form -->
                     </span>
 
                     <div class="planner-row">


### PR DESCRIPTION
There are two types of places where the feedback dropdown is used.
1. the last part of a connection
2. vias of a connection

Because the `stop` object of a via looks different than a `connection` object it isn't possible to directly reuse the partial, but this could (in the future) be refactored in a way that they're both extending the same partial

fixes #244 as well
