### PR TITLE
Translate a few more strings

### DIFF
--- a/resources/lang/de/client.php
+++ b/resources/lang/de/client.php
@@ -61,4 +61,5 @@ return [
     'refreshBoard' => 'Erfrischen',
     'marketLink' => 'Download des offiziellen App',
     'errorHoliday' => 'Wir können keine Verbindung finden. An Feiertagen ist es möglich, daß an kleineren Haltestellen keine Züge halten.',
+    'canceled' => 'annulliert',
 ];

--- a/resources/lang/en/client.php
+++ b/resources/lang/en/client.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-    // START OF NEW TRANSLATION STRINGS
     'planNewRoute' => 'Plan new route',
     'searchStations' => 'Search stations',
     'typeToStation' => 'Brussels',
@@ -10,6 +9,7 @@ return [
     'confirmSearch' => 'Plan route',
     'departureAtHour' => 'Leave',
     'arrivalAtHour' => 'Arrive',
+    'loading' => 'Loading…',
     'loadingHeader' => 'Loading your results. Sit tight.',
     'loadingSub' => 'Your results will be available within a few seconds.',
     'depart' => 'depart',
@@ -50,7 +50,6 @@ return [
     'delay' => 'delay',
     'historicalDelays' => 'Historical delays',
     'archived' => 'Archived',
-    // END OF NEW TRANSLATION STRINGS
     'search' => 'Search',
     'departure_at' => 'Departure',
     'arrival_at' => 'Arrival',
@@ -119,4 +118,6 @@ return [
     'highOccupied' => 'Very busy',
     'mediumOccupied' => 'Busy',
     'lowOccupied' => 'Not busy',
+    'canceled' => 'canceled',
+    'thanksForUsing' => 'This route was planned on iRail.be. Thank you very much for using our webapp.',
 ];

--- a/resources/lang/fr/client.php
+++ b/resources/lang/fr/client.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-    // START OF NEW TRANSLATION STRINGS: PLEASE TRANSLATE
     'planNewRoute' => 'Planifier un nouveau trajet',
     'searchStations' => 'Rechercher une gare',
     'typeToStation' => 'Bruxelles',
@@ -10,6 +9,7 @@ return [
     'confirmSearch' => 'Recherchez trajet',
     'departureAtHour' => 'Départ',
     'arrivalAtHour' => 'Arrivée',
+    'loading' => 'Chargement…',
     'loadingHeader' => 'Chargement des résultats. Veuillez patienter.',
     'loadingSub' => 'Vos résultats seront disponibles dans quelques secondes.',
     'depart' => 'partir',
@@ -50,7 +50,6 @@ return [
     'delay' => 'de retard',
     'historicalDelays' => 'Histoire de retard',
     'archived' => 'Archivée',
-    // END OF NEW TRANSLATION STRINGS
     'search' => 'Chercher',
     'departure_at' => 'Départ',
     'arrival_at' => 'Arrivée',
@@ -119,4 +118,6 @@ return [
     'highOccupied' => 'Très chargé',
     'mediumOccupied' => 'Chargé',
     'lowOccupied' => 'Pas chargé',
+    'canceled' => 'annulé',
+    'thanksForUsing' => 'Cette route a été planifié par iRail.be. Merci pour utiliser notre application web.',
 ];

--- a/resources/lang/nl/client.php
+++ b/resources/lang/nl/client.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-    // New translation strings
     'planNewRoute' => 'Plan nieuwe route',
     'searchStations' => 'Zoek naar stations',
     'typeToStation' => 'Brussel',
@@ -10,6 +9,7 @@ return [
     'confirmSearch' => 'Plan route',
     'departureAtHour' => 'Vertrek',
     'arrivalAtHour' => 'Aankomst',
+    'loading' => 'Laden…',
     'loadingHeader' => 'Bezig met laden van resultaten.',
     'loadingSub' => 'Uw resultaten zullen over een paar seconden beschikbaar zijn.',
     'depart' => 'vertrekken',
@@ -20,7 +20,6 @@ return [
     'routesFoundDescription' => 'routes gevonden. De optimale route is al uitgebreid. U kan op de andere routes klikken om ze uit te breiden.',
     'reverse' => 'Trip omkeren',
     'planAnother' => 'Andere trip plannen',
-    //
     'errorCheckInput' => 'We konden je tekst niet omzetten naar een station. Gelieve je input te controleren. We suggereren automatisch stations! :)',
     'error' => 'Hmm, er is iets fout gegaan!',
     'errorNoRoutes' => 'We konden geen routes vinden.',
@@ -33,18 +32,15 @@ return [
     'stationsIdentical' => 'Uw vertrekstation en bestemmingsstation zijn hetzelfde! We kunnen geen route berekenen waar er geen is :)',
     'quickFilter' => 'Type hier om snel liveboard-resultaten te filteren',
     'noResultsFoundLiveboard' => 'Het spijt ons. Volgens onze data vertrekken er hier geen treinen momenteel.',
-    //
     'language' => 'Kies taal',
     'isPartOf' => 'iRail is een onderdeel van',
-    //
     'stationName' => 'Stationsnaam',
     'stationSearchPlaceholder' => 'Typ om te zoeken naar een station',
     'viewLiveboard' => 'Liveboard bekijken',
-    //
     'platform' => 'Perron',
     'station' => 'Station',
     'liveboardDescription' => 'Hier onder vind je een lijst met alle treinen die naar een bepaald station rijden en hun mogelijke vertragingen.',
-    //
+    'waitBetween' => 'Even wachten',
     'mins' => 'min. overstaptijd',
     '404ErrorTitle' => 'Pagina niet gevonden',
     '404Explanation' => 'We konden deze pagina niet vinden. Als je denkt dat dit een fout is, ',
@@ -54,7 +50,6 @@ return [
     'delay' => 'vertraging',
     'historicalDelays' => 'Geschiedenis van vertragingen',
     'archived' => 'Gearchiveerd',
-    //
     'search' => 'Zoek route',
     'departure_at' => 'Vertrek',
     'arrival_at' => 'Aankomst',
@@ -123,4 +118,6 @@ return [
     'highOccupied' => 'Erg druk',
     'mediumOccupied' => 'Druk',
     'lowOccupied' => 'Niet druk',
+    'canceled' => 'geannulleerd',
+    'thanksForUsing' => 'Deze route was met iRail.be gepland. Bedankt om onze webapp te gebruiken.',
 ];

--- a/resources/views/_partials/route/loading.blade.php
+++ b/resources/views/_partials/route/loading.blade.php
@@ -1,6 +1,6 @@
 <div class="row loading" ng-show="loading">
     <div class="col-md-12 col-sm-12">
-        <div class="loader">Loading...</div>
+        <div class="loader">{{Lang::get('client.loading')}}</div>
         <h4 class="text-center lg">{{Lang::get('client.loadingHeader')}}</h4>
         <p class="small text-center">{{Lang::get('client.loadingSub')}}</p>
     </div>

--- a/resources/views/_partials/route/results.blade.php
+++ b/resources/views/_partials/route/results.blade.php
@@ -140,7 +140,7 @@
                                     +@{{ (stop.departure.delay)/60 }}&prime;
                                 </span>
                                 <span class="delay-route" ng-if="stop.departure.canceled > 0">
-                                    canceled
+                                    {{ Lang::get('client.canceled') }}
                                 </span>
                             </span>
 
@@ -222,7 +222,7 @@
         <div class="visible-print">
             <br/>
             <p>
-                This route was planned on iRail.be. Thank you very much for using our webapp.
+                {{ Lang::get('client.thanksForUsing')}}
             </p>
         </div>
     </div>


### PR DESCRIPTION
There were a few strings that weren't translated yet.

Question: There are some "unsafe" places the language is set with `{!! !!}`. Is there a reason for that, becuause I don't see any obvious reason why some strings are different than others.

[planner.blade.php#L14](https://github.com/iRail/hyperRail/blob/master/resources/views/_partials/route/planner.blade.php#L14) vs [planner.blade.php#L41](https://github.com/iRail/hyperRail/blob/master/resources/views/_partials/route/planner.blade.php#L41) for example

IMHO these should all be changed to `@{{}}`
