### PR TITLE
Set language from browser, accept enter key in planner #242 #243

### DIFF
--- a/app/Http/Controllers/Welcome.php
+++ b/app/Http/Controllers/Welcome.php
@@ -14,7 +14,7 @@ class Welcome extends Controller
 
     public function index()
     {
-        if (! Session::get('lang')) {
+        if (Session::get('lang') == null || empty(Session::get('lang'))) {
             return View('language');
         } else {
             return Redirect::to('route');

--- a/app/Http/Middleware/Language.php
+++ b/app/Http/Middleware/Language.php
@@ -3,10 +3,10 @@
 namespace App\Http\Middleware;
 
 use Closure;
-use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\App;
-use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Facades\Input;
+use Illuminate\Support\Facades\Request;
+use Illuminate\Support\Facades\Session;
 
 class Language
 {
@@ -29,17 +29,17 @@ class Language
      */
     public function handle($request, Closure $next)
     {
-
         $browserLanguage = \Locale::lookup(['nl', 'fr', 'en'], $request->server('HTTP_ACCEPT_LANGUAGE'));
 
         // if the user didn't set a language in the cookie, and a browser language is available, use browser language.
-        if (empty(Session::get('lang') && !empty($browserLanguage))) {
+        if (empty(Session::get('lang') && ! empty($browserLanguage))) {
             $language = $browserLanguage;
         } else {
             $language = (Input::get('lang')) ?: Session::get('lang');
         }
 
         $this->setSupportedLanguage($language);
+
         return $next($request);
     }
 

--- a/app/Http/Middleware/Language.php
+++ b/app/Http/Middleware/Language.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Input;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Session;
+use Locale;
 
 class Language
 {
@@ -29,13 +30,16 @@ class Language
      */
     public function handle($request, Closure $next)
     {
-        $browserLanguage = \Locale::lookup(['nl', 'fr', 'en'], $request->server('HTTP_ACCEPT_LANGUAGE'));
+        $browserLanguage = $this->matchAcceptLanguage($request->server('HTTP_ACCEPT_LANGUAGE'), ['nl', 'fr', 'en']);
 
-        // if the user didn't set a language in the cookie, and a browser language is available, use browser language.
-        if (empty(Session::get('lang') && ! empty($browserLanguage))) {
+        if (!empty(Input::get('lang'))) {
+            // if a language is set in the browser, we need to update the language. User may have requested a switch.
+            $language = Input::get('lang');
+        } elseif (empty(Session::get('lang')) && !empty($browserLanguage)) {
+            // if the user didn't set a language in the cookie, and a browser language is available, use browser language.
             $language = $browserLanguage;
         } else {
-            $language = (Input::get('lang')) ?: Session::get('lang');
+            $language = Session::get('lang');
         }
 
         $this->setSupportedLanguage($language);
@@ -62,5 +66,52 @@ class Language
             App::setLocale($lang);
             Session::put('lang', $lang);
         }
+    }
+
+    /**
+     * Search a HTTP accept-header for a supported language. Take order (weight, q=) into account. Skip unsupported
+     * languages.
+     *
+     * This method has a big avantage over locale_lookup, as locale_lookup will only look at the first language in accept-language.
+     * This method will skip unsupported languages and keep searching for a supported, meaning that if only NL and EN are supported,
+     * da, nl;q=0.5, en;q=0.2 will result in nl being chosen. (vs null return from locale_lookup)
+     *
+     * @param string $header the HTTP accept-language header to search
+     * @param array  $supported the list of supported languages
+     * @return string|null if a language matches, a value from the supported array is returned. If not, null is
+     *     returned.
+     */
+    private function matchAcceptLanguage($header, $supported)
+    {
+
+        // step 1: transform header into array
+        // source for step 1: http://stackoverflow.com/questions/6168519/transform-accept-language-output-in-array
+
+        $values = explode(',', $header);
+
+        $accept_language = array();
+
+        foreach ($values AS $lang) {
+            $cnt = preg_match('/([-a-zA-Z]+)\s*;\s*q=([0-9\.]+)/', $lang, $matches);
+            if ($cnt === 0) {
+                $accept_language[$lang] = 1;
+            } else {
+                $accept_language[$matches[1]] = $matches[2];
+            }
+        }
+
+        // step 2: match array with supported languages
+
+        foreach ($accept_language as $accept_lang => $accept_lang_q) {
+            foreach ($supported as $supported_lang) {
+                // use filterMatches to ensure nl-be, nl, nl-nl all match nl, etc..
+                if (Locale::filterMatches($accept_lang, $supported_lang)) {
+                    return $supported_lang;
+                };
+            }
+        }
+
+        // no match found
+        return null;
     }
 }

--- a/app/Http/Middleware/Language.php
+++ b/app/Http/Middleware/Language.php
@@ -2,12 +2,12 @@
 
 namespace App\Http\Middleware;
 
+use Locale;
 use Closure;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Input;
 use Illuminate\Support\Facades\Request;
 use Illuminate\Support\Facades\Session;
-use Locale;
 
 class Language
 {
@@ -32,10 +32,10 @@ class Language
     {
         $browserLanguage = $this->matchAcceptLanguage($request->server('HTTP_ACCEPT_LANGUAGE'), ['nl', 'fr', 'en']);
 
-        if (!empty(Input::get('lang'))) {
+        if (! empty(Input::get('lang'))) {
             // if a language is set in the browser, we need to update the language. User may have requested a switch.
             $language = Input::get('lang');
-        } elseif (empty(Session::get('lang')) && !empty($browserLanguage)) {
+        } elseif (empty(Session::get('lang')) && ! empty($browserLanguage)) {
             // if the user didn't set a language in the cookie, and a browser language is available, use browser language.
             $language = $browserLanguage;
         } else {
@@ -89,9 +89,9 @@ class Language
 
         $values = explode(',', $header);
 
-        $accept_language = array();
+        $accept_language = [];
 
-        foreach ($values AS $lang) {
+        foreach ($values as $lang) {
             $cnt = preg_match('/([-a-zA-Z]+)\s*;\s*q=([0-9\.]+)/', $lang, $matches);
             if ($cnt === 0) {
                 $accept_language[$lang] = 1;
@@ -107,11 +107,10 @@ class Language
                 // use filterMatches to ensure nl-be, nl, nl-nl all match nl, etc..
                 if (Locale::filterMatches($accept_lang, $supported_lang)) {
                     return $supported_lang;
-                };
+                }
             }
         }
 
         // no match found
-        return null;
     }
 }

--- a/app/Http/Middleware/Language.php
+++ b/app/Http/Middleware/Language.php
@@ -29,9 +29,17 @@ class Language
      */
     public function handle($request, Closure $next)
     {
-        $language = (Input::get('lang')) ?: Session::get('lang');
-        $this->setSupportedLanguage($language);
 
+        $browserLanguage = \Locale::lookup(['nl', 'fr', 'en'], $request->server('HTTP_ACCEPT_LANGUAGE'));
+
+        // if the user didn't set a language in the cookie, and a browser language is available, use browser language.
+        if (empty(Session::get('lang') && !empty($browserLanguage))) {
+            $language = $browserLanguage;
+        } else {
+            $language = (Input::get('lang')) ?: Session::get('lang');
+        }
+
+        $this->setSupportedLanguage($language);
         return $next($request);
     }
 

--- a/public/app/js/iRail/Controllers/PlannerCtrl.js
+++ b/public/app/js/iRail/Controllers/PlannerCtrl.js
@@ -21,12 +21,6 @@ var PlannerCtrl = function ($scope, $http, $filter, $timeout, $window) {
    * FUNCTIONS THAT CAN BE CALLED
    *-------------------------------------------------------*/
 
-  $(document).keypress(function (e) {
-    if(e.which === 13){
-      $("#confirm").focus();
-    }
-  });
-
   /**
    *  Check if we can dump the data
    */

--- a/resources/views/_partials/route/planner.blade.php
+++ b/resources/views/_partials/route/planner.blade.php
@@ -6,13 +6,15 @@
         </a>
     </script>
 
+    <form>
+
     <div class="row">
 
         <div class="col-sm-6">
             <div class="form-group">
                 <div class="input-group-oneliner has-affix">
                     <label for="departureStation" class="input-group-label">{{ Lang::get('client.fromStation') }}</label>
-                    <input type="text" id="departureStation" ng-model="departure" placeholder="{{ Lang::get('client.typeFromStation') }}" typeahead="station as station.name for station in getStations($viewValue)" typeahead-template-url="customTemplate.html" class="form-control input-lg" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false">
+                    <input type="text" id="departureStation" ng-model="departure" placeholder="{{ Lang::get('client.typeFromStation') }}" typeahead="station as station.name for station in getStations($viewValue)" typeahead-template-url="customTemplate.html" class="form-control input-lg" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" autofocus>
                     <a class="input-group-affix" ng-click="reverse()" ng-show="results"><i class="fa fa-exchange"></i> <span class="sr-only">{{Lang::get('client.reverse')}}</span></a>
                 </div>
             </div>
@@ -66,7 +68,7 @@
             </button>
         </div>
     </div>
-
+    </form>
     <div class="alert alert-danger" ng-show="data === null">
         <p ng-show="stationnotfound === true">
             {{ Lang::get('client.errorCheckInput') }}

--- a/tests/App/Http/Middleware/LanguageMiddlewareTest.php
+++ b/tests/App/Http/Middleware/LanguageMiddlewareTest.php
@@ -17,6 +17,39 @@ class LanguageMiddlewareTest extends TestCase
         $this->setAssertLanguageTest('fr', 'fr');
     }
 
+    public function testSetLanguageToFrenchWhileBrowserDutch()
+    {
+        // GET parameters should have priority over browser language.
+        $response = $this->get('/?lang=fr', ['accept-language' => 'nl-be']);
+        $this->assertEquals('fr', $this->getApplicationLanguage());
+    }
+
+    public function testSetLanguageFromBrowser()
+    {
+        $response = $this->get('/', ['accept-language' => 'nl-be']);
+        $this->assertEquals('nl', $this->getApplicationLanguage());
+    }
+
+    public function testSetLanguageFromBrowser2()
+    {
+        $response = $this->get('/', ['accept-language' => 'nl']);
+        $this->assertEquals('nl', $this->getApplicationLanguage());
+    }
+
+    public function testSetLanguageFromBrowser3()
+    {
+        // unsupported languages mixed with supported. Should pick first supported.
+        $response = $this->get('/', ['accept-language' => 'da, nl;q=0.9, en;q=0.5']);
+        $this->assertEquals('nl', $this->getApplicationLanguage());
+    }
+
+    public function testSetLanguageFromBrowser4()
+    {
+        // unsupported languages. Should fall back to en.
+        $response = $this->get('/', ['accept-language' => 'da, se;q=0.9, no;q=0.5']);
+        $this->assertEquals('en', $this->getApplicationLanguage());
+    }
+
     public function testFallbackToDefaultLanguageWhenLanguageDoesNotExist()
     {
         $this->setAssertLanguageTest('en', 'NotALanguage');

--- a/tests/VariousTest.php
+++ b/tests/VariousTest.php
@@ -5,8 +5,9 @@ class VariousTest extends TestCase
 {
     public function testHome()
     {
+        // expect redirect, since call includes "accept-language" header
         $response = $this->call('GET', '/');
-        $this->assertEquals(200, $response->status());
+        $this->assertEquals(302, $response->status());
     }
 
     public function testContributors()


### PR DESCRIPTION
Resolves issues #242 and #243.
Note: 
\Locale::lookup is a php function from the php_intl module. The page won't show if this module is not available.