### PR TITLE
Typo: Add missing space.

### DIFF
--- a/resources/views/stations/departureConnection.blade.php
+++ b/resources/views/stations/departureConnection.blade.php
@@ -11,7 +11,7 @@
     <meta name="twitter:domain" content="https://iRail.be">
     <meta name="twitter:description"
           content="Train to {{$direction}} departing at {{$departureStation->name}} leaves today at platform {{$stop['platform']}} at {{date('H:i', strtotime($stop['scheduledDepartureTime']))}}<?php if ($stop['delay'] > 0) {
-              echo "with a delay of " . ($stop['delay'] / 60) . ' minutes';
+              echo " with a delay of " . ($stop['delay'] / 60) . ' minutes';
           }?>.">
     <meta name="twitter:image" content="{{ URL::asset('images/train.jpg') }}">
     <meta property="og:title" content="iRail.be"/>


### PR DESCRIPTION
Hi,

While working on a custom app posting delays on [Twitter](https://twitter.com/sncbalerts) & [Telegram](https://t.me/sncbalerts), I've noticed that there was a missing space in the meta `twitter:description`.

![photo5857448502928452317](https://user-images.githubusercontent.com/252042/33704328-5e940f76-db2c-11e7-9ed2-6d1b7172c000.jpg)

This PR add the missing space.