### PR TITLE
Inputs display fix

### DIFF
--- a/public/app/sass/_component.input-groups.scss
+++ b/public/app/sass/_component.input-groups.scss
@@ -5,7 +5,7 @@
 .input-group-oneliner {
 	position: relative;
 	> input {
-		padding-left: 3.5em;
+		padding-left: 4em;
 		overflow: hidden;
 		text-overflow: ellipsis;
 	}
@@ -16,7 +16,7 @@
 	top: 0;
 	bottom: 0;
 	left: 0;
-	width: 4em;
+	width: 4.5em;
 	height: 100%;
 	padding: 10px 16px;
 	font-size: 18px;


### PR DESCRIPTION
Current version displays "Fro..." because there's not enough space to fit "From" completely. I added .5em in `width` for the label and in `padding-left` for the input itself