### PR TITLE
Add cache headers for some important endpoints

### DIFF
--- a/app/Http/Controllers/RouteController.php
+++ b/app/Http/Controllers/RouteController.php
@@ -2,11 +2,10 @@
 
 namespace App\Http\Controllers;
 
-use Request;
-use App\Http\Requests;
-use Illuminate\Support\Facades\Input;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Input;
 use Illuminate\Support\Facades\Response;
+use Request;
 
 class RouteController extends Controller
 {
@@ -37,9 +36,12 @@ class RouteController extends Controller
             case 'text/html':
                 // In case we want to return html, just let
                 // Laravel render the view and send the headers
+                // This is a static page, where data is retrieved using javascript. Cache the static part for a long time.
                 return Response::view('route.planner')
                     ->header('Content-Type', 'text/html')
-                    ->header('Vary', 'accept');
+                    ->header('Vary', 'accept')
+                    ->header('Expires', (new Carbon())->addHours(24)->toAtomString())
+                    ->header('Cache-Control', 'max-age=86400, s-maxage=43200');
                 break;
             case 'application/json':
             default:
@@ -67,19 +69,19 @@ class RouteController extends Controller
             // Optional time
             $time = Input::get('time');
             // If time is not set, default to now
-            if (! Input::get('time')) {
+            if (!Input::get('time')) {
                 $time = date('Hi', time());
             }
             // Optional date
             $date = Input::get('date');
             // If date is not set, default to today
-            if (! Input::get('date')) {
+            if (!Input::get('date')) {
                 $date = date('dmy', time());
             }
             // Time selector: does the user want to arrive or depart at this hour?
             // Optional. Default to 'depart at hour' if null.
             $timeSel = Input::get('timeSel');
-            if (! Input::get('timeSel')) {
+            if (!Input::get('timeSel')) {
                 $timeSel = 'depart';
             }
             // Get the app's current language/locale
@@ -88,8 +90,8 @@ class RouteController extends Controller
             $toId = str_replace('http://irail.be/stations/NMBS/', '', $to);
             try {
                 $json = file_get_contents('http://api.irail.be/connections.php?to='
-                    .$toId.'&from='.$fromId.'&date='.$date.'&time='.
-                    $time.'&timeSel='.$timeSel.'&lang='.$lang.'&format=json');
+                    . $toId . '&from=' . $fromId . '&date=' . $date . '&time=' .
+                    $time . '&timeSel=' . $timeSel . '&lang=' . $lang . '&format=json');
 
                 return trim($json);
             } catch (ErrorException $ex) {

--- a/app/Http/Controllers/RouteController.php
+++ b/app/Http/Controllers/RouteController.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Input;
-use Illuminate\Support\Facades\Response;
 use Request;
+use Illuminate\Support\Facades\Input;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Response;
 
 class RouteController extends Controller
 {
@@ -49,7 +49,9 @@ class RouteController extends Controller
                 // our JSON by calling our static function 'getJSON()'
                 return Response::make($this::getJSON())
                     ->header('Content-Type', 'application/json')
-                    ->header('Vary', 'accept');
+                    ->header('Vary', 'accept')
+                    ->header('Expires', (new Carbon())->addSeconds(30)->toAtomString())
+                    ->header('Cache-Control', 'max-age=30');
                 break;
         }
     }
@@ -69,19 +71,19 @@ class RouteController extends Controller
             // Optional time
             $time = Input::get('time');
             // If time is not set, default to now
-            if (!Input::get('time')) {
+            if (! Input::get('time')) {
                 $time = date('Hi', time());
             }
             // Optional date
             $date = Input::get('date');
             // If date is not set, default to today
-            if (!Input::get('date')) {
+            if (! Input::get('date')) {
                 $date = date('dmy', time());
             }
             // Time selector: does the user want to arrive or depart at this hour?
             // Optional. Default to 'depart at hour' if null.
             $timeSel = Input::get('timeSel');
-            if (!Input::get('timeSel')) {
+            if (! Input::get('timeSel')) {
                 $timeSel = 'depart';
             }
             // Get the app's current language/locale
@@ -90,8 +92,8 @@ class RouteController extends Controller
             $toId = str_replace('http://irail.be/stations/NMBS/', '', $to);
             try {
                 $json = file_get_contents('http://api.irail.be/connections.php?to='
-                    . $toId . '&from=' . $fromId . '&date=' . $date . '&time=' .
-                    $time . '&timeSel=' . $timeSel . '&lang=' . $lang . '&format=json');
+                    .$toId.'&from='.$fromId.'&date='.$date.'&time='.
+                    $time.'&timeSel='.$timeSel.'&lang='.$lang.'&format=json');
 
                 return trim($json);
             } catch (ErrorException $ex) {

--- a/app/Http/Controllers/StationController.php
+++ b/app/Http/Controllers/StationController.php
@@ -2,21 +2,21 @@
 
 namespace App\Http\Controllers;
 
-use App\hyperRail\FormatConvertor;
+use Request;
 use Carbon\Carbon;
-use EasyRdf_Format;
 use EasyRdf_Graph;
+use EasyRdf_Format;
+use ML\JsonLD\JsonLD;
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\ClientException;
+use Mockery\Exception;
+use irail\stations\Stations;
+use Negotiation\FormatNegotiator;
+use App\hyperRail\FormatConvertor;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Input;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\Support\Facades\Response;
-use irail\stations\Stations;
-use ML\JsonLD\JsonLD;
-use Mockery\Exception;
-use Negotiation\FormatNegotiator;
-use Request;
+use GuzzleHttp\Exception\ClientException;
 
 class StationController extends Controller
 {
@@ -119,10 +119,10 @@ class StationController extends Controller
 
                 $stationStringName = Stations::getStationFromId($station_id);
 
-                if (!$archived) {
+                if (! $archived) {
                     // Set up path to old api
-                    $URL = 'http://api.irail.be/liveboard/?station=' . urlencode($stationStringName->name) .
-                        '&date=' . date('dmy', $datetime) . '&time=' . date('Hi', $datetime) .
+                    $URL = 'http://api.irail.be/liveboard/?station='.urlencode($stationStringName->name).
+                        '&date='.date('dmy', $datetime).'&time='.date('Hi', $datetime).
                         '&fast=true&lang=nl&format=json';
 
                     // Get the contents.
@@ -146,8 +146,8 @@ class StationController extends Controller
                     // If no match is found, attempt to look in the archive
                     // Fetch file using curl
                     $ch = curl_init(
-                        'http://archive.irail.be/' . 'irail?subject=' .
-                        urlencode('http://irail.be/stations/NMBS/' . $station_id . '/departures/' . $liveboard_id)
+                        'http://archive.irail.be/'.'irail?subject='.
+                        urlencode('http://irail.be/stations/NMBS/'.$station_id.'/departures/'.$liveboard_id)
                     );
                     curl_setopt($ch, CURLOPT_HEADER, 0);
                     $request_headers[] = 'Accept: text/turtle';
@@ -169,7 +169,7 @@ class StationController extends Controller
                     $format = EasyRdf_Format::getFormat('jsonld');
                     $output = $graph->serialise($format);
 
-                    if (!is_scalar($output)) {
+                    if (! is_scalar($output)) {
                         $output = var_export($output, true);
                     }
 
@@ -197,7 +197,7 @@ class StationController extends Controller
                     $compacted = JsonLD::compact($output, $jsonContext);
 
                     // Print the resulting JSON-LD!
-                    $urlToFind = 'NMBS/' . $station_id . '/departures/' . $liveboard_id;
+                    $urlToFind = 'NMBS/'.$station_id.'/departures/'.$liveboard_id;
                     $stationDataFallback = json_decode(JsonLD::toString($compacted, true));
 
                     foreach ($stationDataFallback->{'@graph'} as $graph) {
@@ -214,9 +214,9 @@ class StationController extends Controller
             case 'application/ld+json':
             default:
                 $stationStringName = Stations::getStationFromId($station_id);
-                if (!$archived) {
-                    $URL = 'http://api.irail.be/liveboard/?station=' . urlencode($stationStringName->name) .
-                        '&date=' . date('dmy', $datetime) . '&time=' . date('Hi', $datetime) .
+                if (! $archived) {
+                    $URL = 'http://api.irail.be/liveboard/?station='.urlencode($stationStringName->name).
+                        '&date='.date('dmy', $datetime).'&time='.date('Hi', $datetime).
                         '&fast=true&lang=nl&format=json';
                     $data = file_get_contents($URL);
                     $newData = FormatConvertor::convertLiveboardData($data, $station_id);
@@ -241,8 +241,8 @@ class StationController extends Controller
                 } else {
                     // If no match is found, attempt to look in the archive
                     // Fetch file using curl
-                    $ch = curl_init('http://archive.irail.be/' . 'irail?subject=' .
-                        urlencode('http://irail.be/stations/NMBS/' . $station_id . '/departures/' . $liveboard_id));
+                    $ch = curl_init('http://archive.irail.be/'.'irail?subject='.
+                        urlencode('http://irail.be/stations/NMBS/'.$station_id.'/departures/'.$liveboard_id));
                     curl_setopt($ch, CURLOPT_HEADER, 0);
                     $request_headers[] = 'Accept: text/turtle';
                     curl_setopt($ch, CURLOPT_HTTPHEADER, $request_headers);
@@ -259,7 +259,7 @@ class StationController extends Controller
                     // Export to JSON LD
                     $format = EasyRdf_Format::getFormat('jsonld');
                     $output = $graph->serialise($format);
-                    if (!is_scalar($output)) {
+                    if (! is_scalar($output)) {
                         $output = var_export($output, true);
                     }
                     // First, define the context
@@ -283,7 +283,7 @@ class StationController extends Controller
                     // Compact the JsonLD by using @context
                     $compacted = JsonLD::compact($output, $jsonContext);
                     // Print the resulting JSON-LD!
-                    $urlToFind = 'NMBS/' . $station_id . '/departures/' . $liveboard_id;
+                    $urlToFind = 'NMBS/'.$station_id.'/departures/'.$liveboard_id;
                     $stationDataFallback = json_decode(JsonLD::toString($compacted, true));
                     foreach ($stationDataFallback->{'@graph'} as $graph) {
                         if (strpos($graph->{'@id'}, $urlToFind) !== false) {
@@ -309,14 +309,14 @@ class StationController extends Controller
         $priorities = ['application/json', 'text/html', '*/*'];
         $result = $negotiator->getBest($acceptHeader, $priorities);
         $val = $result->getValue();
-        $station_id = '00' . $hafas_id;
+        $station_id = '00'.$hafas_id;
 
         // Convert id to string for interpretation by old API
         $stationObject = Stations::getStationFromId($station_id);
 
         // Set up path to old api
-        $URL = 'http://api.irail.be/vehicle/?id=' . $train_id .
-            '&date=' . date('dmy', strtotime($date)) .
+        $URL = 'http://api.irail.be/vehicle/?id='.$train_id.
+            '&date='.date('dmy', strtotime($date)).
             '&lang=nl&format=json';
 
         try {
@@ -421,15 +421,15 @@ class StationController extends Controller
                     }
 
                     $URL = 'http://api.irail.be/liveboard/?station='
-                        . $stationStringName->name . '&fast=true&lang=nl&format=json&date='
-                        . date('dmy', $datetime) . '&time=' . date('Hi', $datetime);
+                        .$stationStringName->name.'&fast=true&lang=nl&format=json&date='
+                        .date('dmy', $datetime).'&time='.date('Hi', $datetime);
 
                     $guzzleRequest = $guzzleClient->get($URL);
                     $data = $guzzleRequest->getBody();
 
                     try {
                         $newData = FormatConvertor::convertLiveboardData($data, $id);
-                        $jsonLD = (string)json_encode($newData);
+                        $jsonLD = (string) json_encode($newData);
 
                         return Response::make($jsonLD, 200)
                             ->header('Content-Type', 'application/ld+json')
@@ -438,7 +438,7 @@ class StationController extends Controller
                             ->header('Expires', (new Carbon())->addSeconds(30)->toAtomString())
                             ->header('Cache-Control', 'max-age=30');
                     } catch (Exception $ex) {
-                        $error = (string)json_encode(['error' => 'An error occured while parsing the data']);
+                        $error = (string) json_encode(['error' => 'An error occured while parsing the data']);
 
                         return Response::make($error, 500)
                             ->header('Content-Type', 'application/json')
@@ -446,7 +446,7 @@ class StationController extends Controller
                             ->header('access-control-allow-origin', '*');
                     }
                 } catch (\App\Exceptions\StationConversionFailureException $ex) {
-                    $error = (string)json_encode(['error' => 'This station does not exist!']);
+                    $error = (string) json_encode(['error' => 'This station does not exist!']);
                     App::abort(404);
                 }
                 break;

--- a/app/Http/Controllers/StationController.php
+++ b/app/Http/Controllers/StationController.php
@@ -395,8 +395,8 @@ class StationController extends Controller
                     return Response::view('stations.liveboard', $data)
                         ->header('Content-Type', 'text/html')
                         ->header('Vary', 'accept')
-                        ->header('Expires', (new Carbon())->addSeconds(30)->toAtomString())
-                        ->header('Cache-Control', 'max-age=30, must-revalidate');
+                        ->header('Expires', (new Carbon())->addHours(24)->toAtomString())
+                        ->header('Cache-Control', 'max-age=86400, s-maxage=43200');
                     break;
                 } catch (\App\Exceptions\StationConversionFailureException $ex) {
                     App::abort(404);


### PR DESCRIPTION
Add cache headers with max-age depending on how often the content changes #345

Cache headers with a max-age of 24h have been added for
- The static route planner page
- The static station lookup page
- The static liveboard result page
- The station search by name queries, as stations.csv doesn't change often and changes aren't super important

Cache headers with a max-age of 30 seconds have been added for:
- Liveboard results (Json)
- Route results (Json)

This PR will cause a minor reduction of server load, but will mostly improve the user experience for users visiting the website or searching for station names.